### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,8 +6,8 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Filter 				KEYWORD1
-filters				KEYWORD1
+Filter	KEYWORD1
+filters	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
@@ -20,8 +20,8 @@ filters				KEYWORD1
 # Constants (LITERAL1)
 #######################################
 
-ORDER	  			LITERAL1	Constants
-OD1					LITERAL1	Constants
-OD2					LITERAL1	Constants
-OD3					LITERAL1	Constants
-OD4					LITERAL1	Constants
+ORDER	LITERAL1	Constants
+OD1	LITERAL1	Constants
+OD2	LITERAL1	Constants
+OD3	LITERAL1	Constants
+OD4	LITERAL1	Constants


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords