### PR TITLE
Rename EPS,WEPS to EPSILON,WEPSILON to avoid clash with ESP32 headers

### DIFF
--- a/filters.cpp
+++ b/filters.cpp
@@ -227,8 +227,8 @@ inline void  Filter::initHighPass() {
 }
 
 float_t Filter::ap(float_t p) {
-  f_err  = f_err  | (abs(p) <= EPS );
-  f_warn = f_warn | (abs(p) <= WEPS);
+  f_err  = f_err  | (abs(p) <= EPSILON );
+  f_warn = f_warn | (abs(p) <= WEPSILON);
   return (f_err) ? 0.0 : p;
 }
 

--- a/filters_defs.h
+++ b/filters_defs.h
@@ -38,7 +38,7 @@ namespace IIR {
   const float_t SQRT3 = sqrt(3.0);
   const float_t SQRT5 = sqrt(5.0);
 
-  const float_t EPS   = 0.00001;    // Tolerance for numerical constants
-  const float_t WEPS  = 0.00010;    // Warning threshold for numerical degradation
-  const float_t KM    = 100.0;      // Pre-multiplier to reduce the impact of the AVRs limited float representation
+  const float_t EPSILON   = 0.00001;    // Tolerance for numerical constants
+  const float_t WEPSILON  = 0.00010;    // Warning threshold for numerical degradation
+  const float_t KM        = 100.0;      // Pre-multiplier to reduce the impact of the AVRs limited float representation
 }


### PR DESCRIPTION
The Espressif ESP32 headers define a value called "EPS". This conflicts with the "EPS" definition in libFilter and prevents compilation.

This PR renames libFilter's EPS constants to EPSILON to resolve the name clash.